### PR TITLE
log4j 코드 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/**
+.idea/**

--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,6 @@
             <version>2.4</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/log4j/log4j -->
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
-
         <!-- https://mvnrepository.com/artifact/org.semweb4j/rdf2go.api -->
         <dependency>
             <groupId>org.semweb4j</groupId>
@@ -87,19 +80,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.7</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12 -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.7</version>
+            <version>1.7.36</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/github/makbn/thumbnailer/ThumbnailerManager.java
+++ b/src/main/java/io/github/makbn/thumbnailer/ThumbnailerManager.java
@@ -24,10 +24,10 @@ package io.github.makbn.thumbnailer;
 import io.github.makbn.thumbnailer.thumbnailers.Thumbnailer;
 import io.github.makbn.thumbnailer.util.ChainedHashMap;
 import io.github.makbn.thumbnailer.util.IOUtil;
-import io.github.makbn.thumbnailer.util.StringUtil;
 import io.github.makbn.thumbnailer.util.mime.MimeTypeDetector;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -84,7 +84,7 @@ public class ThumbnailerManager implements Thumbnailer {
     /**
      * The logger for this class
      */
-    private static Logger mLog = Logger.getLogger(ThumbnailerManager.class);
+    protected static Logger mLog = LoggerFactory.getLogger(ThumbnailerManager.class);
 
 
     /**
@@ -126,7 +126,7 @@ public class ThumbnailerManager implements Thumbnailer {
     /**
      * Calculate a thumbnail filename (via hashing).
      *
-     * @param input      Input file
+     * @param input Input file
      * @return The chosen filename
      */
     public File chooseThumbnailFilename(File input, String ext) throws ThumbnailerException {
@@ -137,9 +137,9 @@ public class ThumbnailerManager implements Thumbnailer {
 
         File output;
 
-        String name= FilenameUtils.getBaseName(input.getName())+"_thumb";
+        String name = FilenameUtils.getBaseName(input.getName()) + "_thumb";
 
-        name = name+"."+ext;
+        name = name + "." + ext;
 
 
         output = new File(thumbnailFolder, name);
@@ -178,12 +178,12 @@ public class ThumbnailerManager implements Thumbnailer {
      * It is garantueed that an existing Thumbnail is not overwritten by this.
      *
      * @param input Input file that should be processed.
+     * @return Name of Thumbnail-File generated.
      * @throws FileDoesNotExistException
      * @throws IOException
      * @throws ThumbnailerException
-     * @return Name of Thumbnail-File generated.
      */
-    public File createThumbnail(File input,String ext) throws FileDoesNotExistException, IOException, ThumbnailerException {
+    public File createThumbnail(File input, String ext) throws FileDoesNotExistException, IOException, ThumbnailerException {
         File output = chooseThumbnailFilename(input, ext);
         generateThumbnail(input, output);
 
@@ -243,13 +243,13 @@ public class ThumbnailerManager implements Thumbnailer {
      * <li>First all Thumbnailers that declare to accept such a MIME Type are used
      * <li>Then all Thumbnailers that declare to accept all possible MIME Types.
      *
-     * @param input  Input file that should be processed
-     * @param output File in which should be written
+     * @param input    Input file that should be processed
+     * @param output   File in which should be written
+     * @param mimeType MIME-Type of input file (null if unknown)
      * @throws IOException          If file cannot be read/written.
      * @throws ThumbnailerException If the thumbnailing process failed
      *                              (i.e., no thumbnailer could generate an Thumbnail.
      *                              The last ThumbnailerException is re-thrown.)
-     * @param    mimeType    MIME-Type of input file (null if unknown)
      */
     public void generateThumbnail(File input, File output, String mimeType) throws IOException, ThumbnailerException {
         FileDoesNotExistException.check(input, "The input file");
@@ -301,8 +301,8 @@ public class ThumbnailerManager implements Thumbnailer {
      * @param input            Input File that should be processed
      * @param output           Output file where the image shall be written.
      * @param detectedMimeType MIME Type that was returned by automatic MIME Detection
-     * @throws IOException Input file cannot be read, or output file cannot be written, or necessary temporary files could not be created.
      * @return True on success (1 thumbnailer could generate the output file).
+     * @throws IOException Input file cannot be read, or output file cannot be written, or necessary temporary files could not be created.
      */
     private boolean executeThumbnailers(String useMimeType, File input, File output, String detectedMimeType) throws IOException {
         for (Thumbnailer thumbnailer : thumbnailers.getIterable(useMimeType)) {

--- a/src/main/java/io/github/makbn/thumbnailer/thumbnailers/JODConverterThumbnailer.java
+++ b/src/main/java/io/github/makbn/thumbnailer/thumbnailers/JODConverterThumbnailer.java
@@ -28,12 +28,12 @@ import io.github.makbn.thumbnailer.util.Platform;
 import io.github.makbn.thumbnailer.util.TemporaryFilesManager;
 import io.github.makbn.thumbnailer.util.mime.MimeTypeDetector;
 import org.apache.commons.io.FilenameUtils;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
 import org.jodconverter.OfficeDocumentConverter;
 import org.jodconverter.office.LocalOfficeManager;
 import org.jodconverter.office.OfficeException;
 import org.jodconverter.office.OfficeManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,7 +45,7 @@ public abstract class JODConverterThumbnailer extends AbstractThumbnailer {
      * How long may a service work take? (in ms)
      */
     private static final long TIMEOUT = 3600000;
-    protected static Logger mLog = LogManager.getLogger(JODConverterThumbnailer.class.getName());
+    protected static Logger mLog = LoggerFactory.getLogger(JODConverterThumbnailer.class.getName());
     /**
      * JOD Office Manager
      */
@@ -125,7 +125,7 @@ public abstract class JODConverterThumbnailer extends AbstractThumbnailer {
             officeManager.start();
             mLog.warn("openoffice server started!");
         } catch (OfficeException e) {
-            mLog.warn(e);
+            mLog.warn("{}", e);
         }
         officeConverter = new OfficeDocumentConverter(officeManager);
     }
@@ -158,7 +158,7 @@ public abstract class JODConverterThumbnailer extends AbstractThumbnailer {
 
         File outputTmp = null;
         try {
-            outputTmp = File.createTempFile("jodtemp",   "." + getStandardOpenOfficeExtension());
+            outputTmp = File.createTempFile("jodtemp", "." + getStandardOpenOfficeExtension());
 
             if (Platform.isWindows())
                 input = new File(input.getAbsolutePath().replace("\\\\", "\\"));
@@ -166,7 +166,7 @@ public abstract class JODConverterThumbnailer extends AbstractThumbnailer {
             try {
                 officeConverter.convert(input, outputTmp);
             } catch (OfficeException e) {
-                mLog.warn(e);
+                mLog.warn("{}", e);
                 throw new ThumbnailerException();
 
             }

--- a/src/main/java/io/github/makbn/thumbnailer/util/ResizeImage.java
+++ b/src/main/java/io/github/makbn/thumbnailer/util/ResizeImage.java
@@ -23,7 +23,8 @@ package io.github.makbn.thumbnailer.util;
 
 import io.github.makbn.thumbnailer.ThumbnailerException;
 import io.github.makbn.thumbnailer.UnsupportedInputFileFormatException;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
@@ -35,7 +36,7 @@ import java.io.InputStream;
 
 public class ResizeImage {
 
-    private static final Logger mLog = Logger.getLogger(ResizeImage.class);
+    protected static Logger mLog = LoggerFactory.getLogger(ResizeImage.class);
 
     private BufferedImage inputImage;
     private boolean isProcessed = false;

--- a/src/main/java/io/github/makbn/thumbnailer/util/ThumbnailReadyObserver.java
+++ b/src/main/java/io/github/makbn/thumbnailer/util/ThumbnailReadyObserver.java
@@ -1,6 +1,7 @@
 package io.github.makbn.thumbnailer.util;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.image.ImageObserver;
@@ -18,7 +19,7 @@ public class ThumbnailReadyObserver implements ImageObserver {
     /**
      * The logger for this class
      */
-    private final static Logger mLog = Logger.getLogger(ThumbnailReadyObserver.class);
+    protected static Logger mLog = LoggerFactory.getLogger(ThumbnailReadyObserver.class);
 
     public volatile boolean ready = false;
 

--- a/src/main/java/io/github/makbn/thumbnailer/util/mime/MimeTypeDetector.java
+++ b/src/main/java/io/github/makbn/thumbnailer/util/mime/MimeTypeDetector.java
@@ -22,7 +22,8 @@
 package io.github.makbn.thumbnailer.util.mime;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,7 +45,8 @@ public class MimeTypeDetector {
     private List<MimeTypeIdentifier> extraIdentifiers;
     private Map<String, List<String>> extensionsCache = new HashMap<String, List<String>>();
     private static Map<String, String> outputThumbnailExtensionCache;
-    private static Logger mLog = Logger.getLogger(MimeTypeDetector.class);
+    protected static Logger mLog = LoggerFactory.getLogger(MimeTypeDetector.class);
+
     /**
      * Create a MimeType Detector and init it.
      */
@@ -58,13 +60,13 @@ public class MimeTypeDetector {
         addMimeTypeIdentifier(new MP3FileIdentifier());
         addMimeTypeIdentifier(new MPEGFileIdentifier());
 
-        if(outputThumbnailExtensionCache == null){
+        if (outputThumbnailExtensionCache == null) {
             outputThumbnailExtensionCache = new HashMap<>();
 
-            for(MimeTypeIdentifier identifier:extraIdentifiers){
+            for (MimeTypeIdentifier identifier : extraIdentifiers) {
                 List<String> exts = identifier.getExtensionsFor(null);
-                if(exts!= null)
-                    exts.forEach(ext -> outputThumbnailExtensionCache.put(ext,identifier.getThumbnailExtension()));
+                if (exts != null)
+                    exts.forEach(ext -> outputThumbnailExtensionCache.put(ext, identifier.getThumbnailExtension()));
             }
         }
 
@@ -131,7 +133,7 @@ public class MimeTypeDetector {
             return extensions;
 
         extensions = new ArrayList<>();
-        switch (mimeType){
+        switch (mimeType) {
             case "application/vnd.openxmlformats-officedocument.wordprocessingml":
                 extensions.add("docx");
                 extensions.add("dotx");
@@ -189,6 +191,7 @@ public class MimeTypeDetector {
     /**
      * get output file extension for different input file!
      * after first time extension cached for next requests!
+     *
      * @param file
      * @return
      * @throws IOException
@@ -197,13 +200,13 @@ public class MimeTypeDetector {
         String ext = FilenameUtils.getExtension(file.getName());
         String mime = getMimeType(file);
 
-        if(ext!=null) {
-            if(outputThumbnailExtensionCache.containsKey(ext))
+        if (ext != null) {
+            if (outputThumbnailExtensionCache.containsKey(ext))
                 return outputThumbnailExtensionCache.get(ext);
 
             for (MimeTypeIdentifier identifier : extraIdentifiers) {
                 List<String> exts = identifier.getExtensionsFor(mime);
-                if (ext !=null && ext.contains(ext)) {
+                if (ext != null && ext.contains(ext)) {
                     String result = identifier.getThumbnailExtension();
                     outputThumbnailExtensionCache.put(ext, result);
                     return result;


### PR DESCRIPTION
JThumbnail에 의존하는 프로젝트에서 log4j1.2 버전 exclude가 안되어서 log4j에 의존하지 않도록 수정하였습니다.